### PR TITLE
Add AGENTS.md for Cursor Cloud development environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,28 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+Single-service Next.js 16.1 landing page. See `CLAUDE.md` and `README.md` for standard commands (`yarn dev`, `yarn build`, `yarn lint`).
+
+### Environment variables
+
+`lib/supabase.ts` throws at import time if `SUPABASE_URL` or `SUPABASE_ANON_KEY` are missing. Create `.env.local` with placeholder values if real credentials are unavailable:
+
+```
+SUPABASE_URL=https://placeholder.supabase.co
+SUPABASE_ANON_KEY=placeholder-anon-key
+```
+
+The landing page UI works fully without real Supabase credentials. Only `POST /api/waitlist` and `/share/*` routes require a live Supabase instance.
+
+### Dev server
+
+`yarn dev` starts on port 3000 with Turbopack. Cold start compiles are ~2s; subsequent page loads are fast.
+
+### Build
+
+`yarn build` runs `prettier --check` and `eslint` before `next build`. Expect 3 existing lint warnings (unused vars in share routes) — these are non-blocking.
+
+### Corepack
+
+Yarn 4.12.0 is managed via Corepack. Run `corepack enable` before `yarn install` if Yarn is not available.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `AGENTS.md` with Cursor Cloud specific development instructions for future cloud agents.

### What it contains
- Environment variable requirements (`SUPABASE_URL`, `SUPABASE_ANON_KEY` placeholders needed in `.env.local`)
- Dev server, build, and lint notes
- Corepack setup reminder

### Verified
- `yarn lint` — passes (0 errors, 3 existing warnings)
- `yarn build` — compiles and generates all routes successfully
- `yarn dev` — starts on port 3000, serves landing page with 200 status
- Waitlist modal flow tested end-to-end (UI functional, API processes requests)

[mapier_landing_page_waitlist_demo.mp4](https://cursor.com/agents/bc-2f6c5565-28a5-4a5a-a344-ee1787bc1177/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmapier_landing_page_waitlist_demo.mp4)

[Landing page loaded](https://cursor.com/agents/bc-2f6c5565-28a5-4a5a-a344-ee1787bc1177/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flanding_page_loaded.webp)
[Waitlist form submitted](https://cursor.com/agents/bc-2f6c5565-28a5-4a5a-a344-ee1787bc1177/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fwaitlist_form_submitted.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2f6c5565-28a5-4a5a-a344-ee1787bc1177"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2f6c5565-28a5-4a5a-a344-ee1787bc1177"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

