### PR TITLE
Add support, privacy, and terms pages for Apple Developer compliance

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -688,3 +688,513 @@ body.is-releasing {
   opacity: 0.6;
   cursor: default;
 }
+
+/* Landing footer nav links */
+.footer-bar__links {
+  display: flex;
+  gap: 20px;
+  pointer-events: auto;
+}
+
+.footer-bar__links a {
+  color: var(--color-text);
+  text-decoration: none;
+  font-size: 14px;
+  font-weight: 600;
+  opacity: 0.7;
+  transition: opacity 0.2s;
+}
+
+.footer-bar__links a:hover {
+  opacity: 1;
+}
+
+/* ─── Scrollable page layout ─── */
+html.page-scrollable,
+html.page-scrollable body {
+  overflow: auto;
+  height: auto;
+}
+
+.page-layout {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background: var(--color-bg);
+}
+
+.page-header {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 40px;
+  background: rgba(255, 255, 255, 0.85);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.page-header__logo {
+  font-family: "Hornbill", Georgia, serif;
+  font-size: 28px;
+  font-weight: 700;
+  color: var(--color-text);
+  text-decoration: none;
+  letter-spacing: -0.02em;
+}
+
+.page-header__nav {
+  display: flex;
+  gap: 28px;
+}
+
+.page-header__link {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--color-text);
+  text-decoration: none;
+  opacity: 0.7;
+  transition: opacity 0.2s;
+}
+
+.page-header__link:hover {
+  opacity: 1;
+}
+
+.page-main {
+  flex: 1;
+  width: 100%;
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 48px 24px 80px;
+}
+
+/* Page sections */
+.page-section {
+  margin-bottom: 48px;
+}
+
+.page-section--highlight {
+  background: #f8f9fb;
+  border-radius: 20px;
+  padding: 40px 32px;
+}
+
+.page-title {
+  font-family: "Hornbill", Georgia, serif;
+  font-size: clamp(36px, 5vw, 52px);
+  font-weight: 700;
+  color: var(--color-text);
+  letter-spacing: -0.02em;
+  line-height: 1.1;
+  margin-bottom: 12px;
+}
+
+.page-subtitle {
+  font-size: 16px;
+  color: var(--color-text-muted);
+  font-weight: 400;
+  line-height: 1.6;
+}
+
+.page-section-title {
+  font-size: 22px;
+  font-weight: 700;
+  color: var(--color-text);
+  margin-bottom: 20px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+/* FAQ */
+.faq-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.faq-item {
+  border: 1px solid var(--color-border);
+  border-radius: 14px;
+  overflow: hidden;
+  transition: border-color 0.2s;
+}
+
+.faq-item--open {
+  border-color: var(--color-text);
+}
+
+.faq-item__q {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px;
+  background: none;
+  border: none;
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--color-text);
+  cursor: pointer;
+  text-align: left;
+}
+
+.faq-item__chevron {
+  flex-shrink: 0;
+  transition: transform 0.2s;
+}
+
+.faq-item--open .faq-item__chevron {
+  transform: rotate(180deg);
+}
+
+.faq-item__a {
+  padding: 0 20px 16px;
+  font-size: 14px;
+  font-weight: 400;
+  color: var(--color-text-muted);
+  line-height: 1.7;
+}
+
+/* Support contact grid */
+.support-contact-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
+}
+
+.support-contact-card {
+  padding: 24px;
+  border: 1px solid var(--color-border);
+  border-radius: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.support-contact-card h3 {
+  font-size: 16px;
+  font-weight: 700;
+}
+
+.support-contact-card p {
+  font-size: 14px;
+  font-weight: 400;
+  color: var(--color-text-muted);
+  line-height: 1.6;
+}
+
+.support-contact-link {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--color-primary);
+  text-decoration: none;
+}
+
+.support-contact-link:hover {
+  text-decoration: underline;
+}
+
+/* Support form */
+.support-form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.support-form__row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+}
+
+.support-form__field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.support-form__field label {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.support-form__field input,
+.support-form__field textarea {
+  padding: 12px 16px;
+  border: 1.5px solid var(--color-border);
+  border-radius: 12px;
+  font-size: 15px;
+  font-weight: 400;
+  color: var(--color-text);
+  background: var(--color-bg);
+  outline: none;
+  transition: border-color 0.2s;
+  font-family: inherit;
+  resize: vertical;
+}
+
+.support-form__field input:focus,
+.support-form__field textarea:focus {
+  border-color: var(--color-text);
+}
+
+.support-form-success {
+  text-align: center;
+  padding: 32px;
+  border: 1px solid var(--color-border);
+  border-radius: 16px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+}
+
+.support-form-success p {
+  font-size: 15px;
+  color: var(--color-text-muted);
+  font-weight: 400;
+}
+
+.page-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 14px 28px;
+  background: var(--color-btn-primary-bg);
+  color: var(--color-btn-primary-text);
+  border: none;
+  border-radius: 220px;
+  font-size: 15px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s;
+  align-self: flex-start;
+}
+
+.page-btn:hover {
+  background: #333;
+}
+
+.page-btn:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+/* About cards */
+.about-cards {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
+}
+
+.about-card {
+  padding: 24px;
+  background: var(--color-bg);
+  border-radius: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  box-shadow: 0 1px 8px rgba(0, 0, 0, 0.04);
+}
+
+.about-card h3 {
+  font-size: 16px;
+  font-weight: 700;
+}
+
+.about-card p {
+  font-size: 14px;
+  font-weight: 400;
+  color: var(--color-text-muted);
+  line-height: 1.6;
+}
+
+/* Legal content */
+.legal-content h2 {
+  font-size: 20px;
+  font-weight: 700;
+  color: var(--color-text);
+  margin-top: 32px;
+  margin-bottom: 12px;
+}
+
+.legal-content h3 {
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--color-text);
+  margin-top: 20px;
+  margin-bottom: 8px;
+}
+
+.legal-content p {
+  font-size: 15px;
+  font-weight: 400;
+  color: var(--color-text);
+  line-height: 1.7;
+  margin-bottom: 12px;
+}
+
+.legal-content ul {
+  list-style: disc;
+  padding-left: 24px;
+  margin-bottom: 12px;
+}
+
+.legal-content li {
+  font-size: 15px;
+  font-weight: 400;
+  color: var(--color-text);
+  line-height: 1.7;
+  margin-bottom: 6px;
+}
+
+.legal-content a {
+  color: var(--color-primary);
+  text-decoration: none;
+}
+
+.legal-content a:hover {
+  text-decoration: underline;
+}
+
+/* Page footer */
+.page-footer {
+  background: #1a1a1a;
+  color: #fff;
+  padding: 48px 40px 24px;
+}
+
+.page-footer__inner {
+  max-width: 800px;
+  margin: 0 auto;
+  display: flex;
+  justify-content: space-between;
+  gap: 40px;
+  padding-bottom: 32px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.page-footer__brand {
+  max-width: 280px;
+}
+
+.page-footer__logo {
+  font-family: "Hornbill", Georgia, serif;
+  font-size: 24px;
+  font-weight: 700;
+  color: #fff;
+  text-decoration: none;
+  display: block;
+  margin-bottom: 8px;
+}
+
+.page-footer__tagline {
+  font-size: 14px;
+  font-weight: 400;
+  color: rgba(255, 255, 255, 0.6);
+  line-height: 1.6;
+}
+
+.page-footer__links {
+  display: flex;
+  gap: 48px;
+}
+
+.page-footer__col {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.page-footer__col h4 {
+  font-size: 13px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: rgba(255, 255, 255, 0.4);
+  margin-bottom: 4px;
+}
+
+.page-footer__col a {
+  font-size: 14px;
+  font-weight: 400;
+  color: rgba(255, 255, 255, 0.8);
+  text-decoration: none;
+  transition: color 0.2s;
+}
+
+.page-footer__col a:hover {
+  color: #fff;
+}
+
+.page-footer__bottom {
+  max-width: 800px;
+  margin: 0 auto;
+  padding-top: 20px;
+  font-size: 13px;
+  color: rgba(255, 255, 255, 0.4);
+  font-weight: 400;
+}
+
+/* Responsive — pages */
+@media (max-width: 768px) {
+  .page-header {
+    padding: 14px 20px;
+  }
+
+  .page-header__logo {
+    font-size: 24px;
+  }
+
+  .page-header__nav {
+    gap: 16px;
+  }
+
+  .page-header__link {
+    font-size: 14px;
+  }
+
+  .page-main {
+    padding: 32px 20px 60px;
+  }
+
+  .support-contact-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .support-form__row {
+    grid-template-columns: 1fr;
+  }
+
+  .about-cards {
+    grid-template-columns: 1fr;
+  }
+
+  .page-footer__inner {
+    flex-direction: column;
+    gap: 32px;
+  }
+
+  .page-footer__links {
+    flex-wrap: wrap;
+    gap: 32px;
+  }
+
+  .page-footer {
+    padding: 32px 20px 20px;
+  }
+
+  .footer-bar__links {
+    gap: 14px;
+  }
+
+  .page-section--highlight {
+    padding: 24px 20px;
+  }
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -703,6 +703,8 @@ body.is-releasing {
   font-weight: 600;
   opacity: 0.7;
   transition: opacity 0.2s;
+  pointer-events: auto;
+  cursor: pointer;
 }
 
 .footer-bar__links a:hover {

--- a/app/privacy/PrivacyPage.tsx
+++ b/app/privacy/PrivacyPage.tsx
@@ -121,7 +121,7 @@ export function PrivacyPage() {
         </ul>
         <p>
           To exercise any of these rights, contact us at{" "}
-          <a href="mailto:privacy@mapier.ai">privacy@mapier.ai</a>.
+          <a href="mailto:hello@mapier.ai">hello@mapier.ai</a>.
         </p>
 
         <h2>8. Children&apos;s Privacy</h2>
@@ -152,7 +152,7 @@ export function PrivacyPage() {
         </p>
         <ul>
           <li>
-            Email: <a href="mailto:privacy@mapier.ai">privacy@mapier.ai</a>
+            Email: <a href="mailto:hello@mapier.ai">hello@mapier.ai</a>
           </li>
           <li>
             Support: <a href="/support">mapier.ai/support</a>

--- a/app/privacy/PrivacyPage.tsx
+++ b/app/privacy/PrivacyPage.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import { PageLayout } from "@/components/PageLayout";
+
+export function PrivacyPage() {
+  return (
+    <PageLayout>
+      <section className="page-section">
+        <h1 className="page-title">Privacy Policy</h1>
+        <p className="page-subtitle">Last updated: April 10, 2025</p>
+      </section>
+
+      <section className="page-section legal-content">
+        <h2>1. Introduction</h2>
+        <p>
+          Mapier Labs Inc. (&quot;Mapier,&quot; &quot;we,&quot; &quot;our,&quot; or &quot;us&quot;)
+          is committed to protecting your privacy. This Privacy Policy explains how we collect, use,
+          disclose, and safeguard your information when you use the Mapier mobile application and
+          website (collectively, the &quot;Service&quot;).
+        </p>
+        <p>
+          By using the Service, you agree to the collection and use of information in accordance
+          with this policy. If you do not agree, please do not use the Service.
+        </p>
+
+        <h2>2. Information We Collect</h2>
+        <h3>2.1 Information You Provide</h3>
+        <ul>
+          <li>
+            <strong>Account Information:</strong> When you create an account, we collect your name,
+            email address, and profile information you choose to provide.
+          </li>
+          <li>
+            <strong>User Content:</strong> Posts, doodles, comments, and other content you create
+            within the app.
+          </li>
+          <li>
+            <strong>Communications:</strong> Messages you send to us via support channels or
+            in-app feedback.
+          </li>
+        </ul>
+
+        <h3>2.2 Information Collected Automatically</h3>
+        <ul>
+          <li>
+            <strong>Location Data:</strong> With your permission, we collect precise geolocation
+            data to power map-based features. You can disable location access at any time through
+            your device settings.
+          </li>
+          <li>
+            <strong>Device Information:</strong> Device type, operating system, unique device
+            identifiers, and mobile network information.
+          </li>
+          <li>
+            <strong>Usage Data:</strong> How you interact with the Service, including features used,
+            pages visited, and time spent.
+          </li>
+          <li>
+            <strong>Log Data:</strong> IP address, browser type, access times, and referring URLs.
+          </li>
+        </ul>
+
+        <h2>3. How We Use Your Information</h2>
+        <p>We use the information we collect to:</p>
+        <ul>
+          <li>Provide, maintain, and improve the Service</li>
+          <li>Personalize your experience with AI-powered recommendations</li>
+          <li>Show you relevant events, places, and people nearby</li>
+          <li>Process and respond to your support requests</li>
+          <li>Send important service updates and notifications</li>
+          <li>Detect, prevent, and address technical issues and abuse</li>
+          <li>Comply with legal obligations</li>
+        </ul>
+
+        <h2>4. How We Share Your Information</h2>
+        <p>We do not sell your personal information. We may share information in these limited circumstances:</p>
+        <ul>
+          <li>
+            <strong>With Other Users:</strong> Your public profile and content you post are visible
+            to other Mapier users based on your privacy settings.
+          </li>
+          <li>
+            <strong>Service Providers:</strong> Trusted third-party companies that help us operate
+            the Service (e.g., hosting, analytics), bound by confidentiality obligations.
+          </li>
+          <li>
+            <strong>Legal Requirements:</strong> When required by law, court order, or governmental
+            authority.
+          </li>
+          <li>
+            <strong>Business Transfers:</strong> In connection with a merger, acquisition, or sale
+            of assets, your information may be transferred.
+          </li>
+        </ul>
+
+        <h2>5. Data Retention</h2>
+        <p>
+          We retain your personal information only for as long as necessary to fulfill the purposes
+          outlined in this policy, unless a longer retention period is required by law. When you
+          delete your account, we will delete or anonymize your personal data within 30 days,
+          except where retention is required for legal compliance.
+        </p>
+
+        <h2>6. Data Security</h2>
+        <p>
+          We implement industry-standard security measures to protect your information, including
+          encryption in transit and at rest, access controls, and regular security audits. However,
+          no method of transmission over the internet is 100% secure, and we cannot guarantee
+          absolute security.
+        </p>
+
+        <h2>7. Your Rights and Choices</h2>
+        <p>You have the right to:</p>
+        <ul>
+          <li>Access the personal data we hold about you</li>
+          <li>Request correction of inaccurate data</li>
+          <li>Request deletion of your account and data</li>
+          <li>Opt out of marketing communications</li>
+          <li>Disable location tracking through your device settings</li>
+          <li>Export your data in a portable format</li>
+        </ul>
+        <p>
+          To exercise any of these rights, contact us at{" "}
+          <a href="mailto:privacy@mapier.ai">privacy@mapier.ai</a>.
+        </p>
+
+        <h2>8. Children&apos;s Privacy</h2>
+        <p>
+          The Service is not intended for children under 13 years of age. We do not knowingly
+          collect personal information from children under 13. If we learn we have collected such
+          information, we will take steps to delete it promptly.
+        </p>
+
+        <h2>9. International Data Transfers</h2>
+        <p>
+          Your information may be transferred to and processed in countries other than your own.
+          We ensure appropriate safeguards are in place for such transfers in compliance with
+          applicable data protection laws.
+        </p>
+
+        <h2>10. Changes to This Policy</h2>
+        <p>
+          We may update this Privacy Policy from time to time. We will notify you of any material
+          changes by posting the updated policy on this page and updating the &quot;Last
+          updated&quot; date. Your continued use of the Service after changes constitutes acceptance
+          of the updated policy.
+        </p>
+
+        <h2>11. Contact Us</h2>
+        <p>
+          If you have questions about this Privacy Policy or our data practices, please contact us:
+        </p>
+        <ul>
+          <li>
+            Email: <a href="mailto:privacy@mapier.ai">privacy@mapier.ai</a>
+          </li>
+          <li>
+            Support: <a href="/support">mapier.ai/support</a>
+          </li>
+        </ul>
+        <p>Mapier Labs Inc.<br />San Francisco, CA</p>
+      </section>
+    </PageLayout>
+  );
+}

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next";
+import { PrivacyPage } from "./PrivacyPage";
+
+export const metadata: Metadata = {
+  title: "Privacy Policy - Mapier",
+  description:
+    "Mapier's privacy policy. Learn how we collect, use, and protect your personal information.",
+  alternates: { canonical: "/privacy" },
+};
+
+export default function Privacy() {
+  return <PrivacyPage />;
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -8,5 +8,23 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: "weekly",
       priority: 1,
     },
+    {
+      url: "https://mapier.ai/support",
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.8,
+    },
+    {
+      url: "https://mapier.ai/privacy",
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.5,
+    },
+    {
+      url: "https://mapier.ai/terms",
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.5,
+    },
   ];
 }

--- a/app/support/SupportPage.tsx
+++ b/app/support/SupportPage.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { PageLayout } from "@/components/PageLayout";
-import { Mail, MessageCircle, Shield, MapPin, User, HelpCircle } from "lucide-react";
+import { Mail, MessageCircle, Shield, HelpCircle } from "lucide-react";
 
 const FAQS = [
   {
@@ -33,18 +33,6 @@ const FAQS = [
 
 export function SupportPage() {
   const [openFaq, setOpenFaq] = useState<number | null>(null);
-  const [formStatus, setFormStatus] = useState<"idle" | "sending" | "sent" | "error">("idle");
-  const [formData, setFormData] = useState({ name: "", email: "", subject: "", message: "" });
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setFormStatus("sending");
-    // Simulate send — replace with real endpoint when available
-    await new Promise((r) => setTimeout(r, 800));
-    setFormStatus("sent");
-    setFormData({ name: "", email: "", subject: "", message: "" });
-  };
-
   return (
     <PageLayout>
       <section className="page-section">
@@ -119,100 +107,6 @@ export function SupportPage() {
         </div>
       </section>
 
-      <section className="page-section">
-        <h2 className="page-section-title">
-          <MessageCircle size={24} />
-          Send Us a Message
-        </h2>
-        {formStatus === "sent" ? (
-          <div className="support-form-success">
-            <p>Thank you! We&apos;ve received your message and will get back to you shortly.</p>
-            <button
-              type="button"
-              className="page-btn"
-              onClick={() => setFormStatus("idle")}
-            >
-              Send Another Message
-            </button>
-          </div>
-        ) : (
-          <form onSubmit={handleSubmit} className="support-form">
-            <div className="support-form__row">
-              <div className="support-form__field">
-                <label htmlFor="support-name">Name</label>
-                <input
-                  id="support-name"
-                  type="text"
-                  required
-                  value={formData.name}
-                  onChange={(e) => setFormData({ ...formData, name: e.target.value })}
-                  placeholder="Your name"
-                />
-              </div>
-              <div className="support-form__field">
-                <label htmlFor="support-email">Email</label>
-                <input
-                  id="support-email"
-                  type="email"
-                  required
-                  value={formData.email}
-                  onChange={(e) => setFormData({ ...formData, email: e.target.value })}
-                  placeholder="you@example.com"
-                />
-              </div>
-            </div>
-            <div className="support-form__field">
-              <label htmlFor="support-subject">Subject</label>
-              <input
-                id="support-subject"
-                type="text"
-                required
-                value={formData.subject}
-                onChange={(e) => setFormData({ ...formData, subject: e.target.value })}
-                placeholder="How can we help?"
-              />
-            </div>
-            <div className="support-form__field">
-              <label htmlFor="support-message">Message</label>
-              <textarea
-                id="support-message"
-                required
-                rows={5}
-                value={formData.message}
-                onChange={(e) => setFormData({ ...formData, message: e.target.value })}
-                placeholder="Describe your issue or question..."
-              />
-            </div>
-            <button type="submit" className="page-btn" disabled={formStatus === "sending"}>
-              {formStatus === "sending" ? "Sending..." : "Send Message"}
-            </button>
-          </form>
-        )}
-      </section>
-
-      <section className="page-section page-section--highlight">
-        <h2 className="page-section-title">
-          <MapPin size={24} />
-          About Mapier
-        </h2>
-        <div className="about-cards">
-          <div className="about-card">
-            <MapPin size={32} />
-            <h3>Live Social Map</h3>
-            <p>See what&apos;s happening around you in real time — events, meetups, local buzz.</p>
-          </div>
-          <div className="about-card">
-            <User size={32} />
-            <h3>Meet Your People</h3>
-            <p>AI-powered matching connects you with people who share your interests nearby.</p>
-          </div>
-          <div className="about-card">
-            <Shield size={32} />
-            <h3>Privacy First</h3>
-            <p>Your location and data stay under your control. We never sell your information.</p>
-          </div>
-        </div>
-      </section>
     </PageLayout>
   );
 }

--- a/app/support/SupportPage.tsx
+++ b/app/support/SupportPage.tsx
@@ -27,7 +27,7 @@ const FAQS = [
   },
   {
     q: "How can I delete my account or data?",
-    a: "Once the app launches, you'll be able to delete your account and all associated data directly from the app settings. You can also contact us at support@mapier.ai to request data deletion.",
+    a: "Once the app launches, you'll be able to delete your account and all associated data directly from the app settings. You can also contact us at hello@mapier.ai to request data deletion.",
   },
 ];
 
@@ -99,8 +99,8 @@ export function SupportPage() {
             <Mail size={28} />
             <h3>Email Support</h3>
             <p>For general inquiries and support requests.</p>
-            <a href="mailto:support@mapier.ai" className="support-contact-link">
-              support@mapier.ai
+            <a href="mailto:hello@mapier.ai" className="support-contact-link">
+              hello@mapier.ai
             </a>
           </div>
           <div className="support-contact-card">
@@ -110,10 +110,10 @@ export function SupportPage() {
           </div>
           <div className="support-contact-card">
             <Shield size={28} />
-            <h3>Privacy Requests</h3>
-            <p>For data deletion or privacy-related requests.</p>
-            <a href="mailto:privacy@mapier.ai" className="support-contact-link">
-              privacy@mapier.ai
+            <h3>Privacy &amp; Data</h3>
+            <p>For data deletion or privacy-related requests, reach out to the same email or read our policy.</p>
+            <a href="/privacy" className="support-contact-link">
+              Privacy Policy
             </a>
           </div>
         </div>

--- a/app/support/SupportPage.tsx
+++ b/app/support/SupportPage.tsx
@@ -1,0 +1,218 @@
+"use client";
+
+import { useState } from "react";
+import { PageLayout } from "@/components/PageLayout";
+import { Mail, MessageCircle, Shield, MapPin, User, HelpCircle } from "lucide-react";
+
+const FAQS = [
+  {
+    q: "What is Mapier?",
+    a: "Mapier is an AI-personalized live map of social and local life. It helps you discover what's happening around you, meet people you vibe with, explore local businesses, and leave creative doodles across the city.",
+  },
+  {
+    q: "When will Mapier be available?",
+    a: "Mapier is currently in development. Join our waitlist on the homepage to be notified when we launch. Early waitlist members will get priority access.",
+  },
+  {
+    q: "Which platforms will Mapier support?",
+    a: "Mapier will be available on both iOS and Android at launch.",
+  },
+  {
+    q: "Is Mapier free to use?",
+    a: "Yes, Mapier will be free to download and use. We may offer optional premium features in the future.",
+  },
+  {
+    q: "How does Mapier protect my privacy?",
+    a: "We take privacy seriously. Location data is used only to power your personalized experience and is never sold to third parties. You can review our full privacy policy for more details.",
+  },
+  {
+    q: "How can I delete my account or data?",
+    a: "Once the app launches, you'll be able to delete your account and all associated data directly from the app settings. You can also contact us at support@mapier.ai to request data deletion.",
+  },
+];
+
+export function SupportPage() {
+  const [openFaq, setOpenFaq] = useState<number | null>(null);
+  const [formStatus, setFormStatus] = useState<"idle" | "sending" | "sent" | "error">("idle");
+  const [formData, setFormData] = useState({ name: "", email: "", subject: "", message: "" });
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setFormStatus("sending");
+    // Simulate send — replace with real endpoint when available
+    await new Promise((r) => setTimeout(r, 800));
+    setFormStatus("sent");
+    setFormData({ name: "", email: "", subject: "", message: "" });
+  };
+
+  return (
+    <PageLayout>
+      <section className="page-section">
+        <h1 className="page-title">Support</h1>
+        <p className="page-subtitle">
+          We&apos;re here to help. Browse our FAQ or contact our team directly.
+        </p>
+      </section>
+
+      <section className="page-section">
+        <h2 className="page-section-title">
+          <HelpCircle size={24} />
+          Frequently Asked Questions
+        </h2>
+        <div className="faq-list">
+          {FAQS.map((faq, i) => (
+            <div key={i} className={`faq-item ${openFaq === i ? "faq-item--open" : ""}`}>
+              <button
+                type="button"
+                className="faq-item__q"
+                onClick={() => setOpenFaq(openFaq === i ? null : i)}
+                aria-expanded={openFaq === i}
+              >
+                <span>{faq.q}</span>
+                <svg
+                  className="faq-item__chevron"
+                  width="20"
+                  height="20"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <polyline points="6 9 12 15 18 9" />
+                </svg>
+              </button>
+              {openFaq === i && <p className="faq-item__a">{faq.a}</p>}
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="page-section">
+        <h2 className="page-section-title">
+          <Mail size={24} />
+          Contact Us
+        </h2>
+        <div className="support-contact-grid">
+          <div className="support-contact-card">
+            <Mail size={28} />
+            <h3>Email Support</h3>
+            <p>For general inquiries and support requests.</p>
+            <a href="mailto:support@mapier.ai" className="support-contact-link">
+              support@mapier.ai
+            </a>
+          </div>
+          <div className="support-contact-card">
+            <MessageCircle size={28} />
+            <h3>Response Time</h3>
+            <p>We aim to respond to all inquiries within 24 hours during business days.</p>
+          </div>
+          <div className="support-contact-card">
+            <Shield size={28} />
+            <h3>Privacy Requests</h3>
+            <p>For data deletion or privacy-related requests.</p>
+            <a href="mailto:privacy@mapier.ai" className="support-contact-link">
+              privacy@mapier.ai
+            </a>
+          </div>
+        </div>
+      </section>
+
+      <section className="page-section">
+        <h2 className="page-section-title">
+          <MessageCircle size={24} />
+          Send Us a Message
+        </h2>
+        {formStatus === "sent" ? (
+          <div className="support-form-success">
+            <p>Thank you! We&apos;ve received your message and will get back to you shortly.</p>
+            <button
+              type="button"
+              className="page-btn"
+              onClick={() => setFormStatus("idle")}
+            >
+              Send Another Message
+            </button>
+          </div>
+        ) : (
+          <form onSubmit={handleSubmit} className="support-form">
+            <div className="support-form__row">
+              <div className="support-form__field">
+                <label htmlFor="support-name">Name</label>
+                <input
+                  id="support-name"
+                  type="text"
+                  required
+                  value={formData.name}
+                  onChange={(e) => setFormData({ ...formData, name: e.target.value })}
+                  placeholder="Your name"
+                />
+              </div>
+              <div className="support-form__field">
+                <label htmlFor="support-email">Email</label>
+                <input
+                  id="support-email"
+                  type="email"
+                  required
+                  value={formData.email}
+                  onChange={(e) => setFormData({ ...formData, email: e.target.value })}
+                  placeholder="you@example.com"
+                />
+              </div>
+            </div>
+            <div className="support-form__field">
+              <label htmlFor="support-subject">Subject</label>
+              <input
+                id="support-subject"
+                type="text"
+                required
+                value={formData.subject}
+                onChange={(e) => setFormData({ ...formData, subject: e.target.value })}
+                placeholder="How can we help?"
+              />
+            </div>
+            <div className="support-form__field">
+              <label htmlFor="support-message">Message</label>
+              <textarea
+                id="support-message"
+                required
+                rows={5}
+                value={formData.message}
+                onChange={(e) => setFormData({ ...formData, message: e.target.value })}
+                placeholder="Describe your issue or question..."
+              />
+            </div>
+            <button type="submit" className="page-btn" disabled={formStatus === "sending"}>
+              {formStatus === "sending" ? "Sending..." : "Send Message"}
+            </button>
+          </form>
+        )}
+      </section>
+
+      <section className="page-section page-section--highlight">
+        <h2 className="page-section-title">
+          <MapPin size={24} />
+          About Mapier
+        </h2>
+        <div className="about-cards">
+          <div className="about-card">
+            <MapPin size={32} />
+            <h3>Live Social Map</h3>
+            <p>See what&apos;s happening around you in real time — events, meetups, local buzz.</p>
+          </div>
+          <div className="about-card">
+            <User size={32} />
+            <h3>Meet Your People</h3>
+            <p>AI-powered matching connects you with people who share your interests nearby.</p>
+          </div>
+          <div className="about-card">
+            <Shield size={32} />
+            <h3>Privacy First</h3>
+            <p>Your location and data stay under your control. We never sell your information.</p>
+          </div>
+        </div>
+      </section>
+    </PageLayout>
+  );
+}

--- a/app/support/page.tsx
+++ b/app/support/page.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next";
+import { SupportPage } from "./SupportPage";
+
+export const metadata: Metadata = {
+  title: "Support - Mapier",
+  description:
+    "Get help with Mapier. Contact our support team, browse FAQs, and find answers to common questions about the Mapier app.",
+  alternates: { canonical: "/support" },
+};
+
+export default function Support() {
+  return <SupportPage />;
+}

--- a/app/terms/TermsPage.tsx
+++ b/app/terms/TermsPage.tsx
@@ -105,7 +105,7 @@ export function TermsPage() {
         <p>
           We may suspend or terminate your access to the Service at any time for any reason,
           including violation of these Terms. You may delete your account at any time through the
-          app settings or by contacting <a href="mailto:support@mapier.ai">support@mapier.ai</a>.
+          app settings or by contacting <a href="mailto:hello@mapier.ai">hello@mapier.ai</a>.
           Upon termination, your right to use the Service ceases immediately.
         </p>
 
@@ -127,7 +127,7 @@ export function TermsPage() {
         <p>For questions about these Terms, please contact us:</p>
         <ul>
           <li>
-            Email: <a href="mailto:legal@mapier.ai">legal@mapier.ai</a>
+            Email: <a href="mailto:hello@mapier.ai">hello@mapier.ai</a>
           </li>
           <li>
             Support: <a href="/support">mapier.ai/support</a>

--- a/app/terms/TermsPage.tsx
+++ b/app/terms/TermsPage.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { PageLayout } from "@/components/PageLayout";
+
+export function TermsPage() {
+  return (
+    <PageLayout>
+      <section className="page-section">
+        <h1 className="page-title">Terms of Service</h1>
+        <p className="page-subtitle">Last updated: April 10, 2025</p>
+      </section>
+
+      <section className="page-section legal-content">
+        <h2>1. Acceptance of Terms</h2>
+        <p>
+          By accessing or using the Mapier mobile application, website, and related services
+          (collectively, the &quot;Service&quot;) provided by Mapier Labs Inc. (&quot;Mapier,&quot;
+          &quot;we,&quot; &quot;our,&quot; or &quot;us&quot;), you agree to be bound by these Terms
+          of Service (&quot;Terms&quot;). If you do not agree to these Terms, do not use the
+          Service.
+        </p>
+
+        <h2>2. Eligibility</h2>
+        <p>
+          You must be at least 13 years of age to use the Service. By using the Service, you
+          represent and warrant that you meet this age requirement. If you are under 18, you must
+          have your parent or guardian&apos;s permission.
+        </p>
+
+        <h2>3. Account Registration</h2>
+        <p>
+          To access certain features, you may need to create an account. You agree to provide
+          accurate, current, and complete information and to keep your account credentials secure.
+          You are responsible for all activity under your account.
+        </p>
+
+        <h2>4. Acceptable Use</h2>
+        <p>You agree not to:</p>
+        <ul>
+          <li>Use the Service for any unlawful purpose</li>
+          <li>Harass, abuse, or harm other users</li>
+          <li>Post content that is defamatory, obscene, or infringes intellectual property rights</li>
+          <li>Impersonate another person or entity</li>
+          <li>Attempt to gain unauthorized access to any part of the Service</li>
+          <li>Use automated means to scrape or collect data from the Service</li>
+          <li>Interfere with the proper operation of the Service</li>
+          <li>Upload malicious code or attempt to compromise system security</li>
+        </ul>
+
+        <h2>5. User Content</h2>
+        <p>
+          You retain ownership of content you create on the Service. By posting content, you grant
+          Mapier a non-exclusive, worldwide, royalty-free license to use, display, and distribute
+          your content in connection with operating and promoting the Service. You are solely
+          responsible for the content you post.
+        </p>
+
+        <h2>6. Intellectual Property</h2>
+        <p>
+          The Service, including its design, features, code, and branding, is owned by Mapier Labs
+          Inc. and protected by copyright, trademark, and other intellectual property laws. You may
+          not copy, modify, distribute, or create derivative works based on the Service without our
+          written permission.
+        </p>
+
+        <h2>7. Location Services</h2>
+        <p>
+          Mapier uses location data to provide its core features. By enabling location services,
+          you consent to the collection and use of your location information as described in our{" "}
+          <a href="/privacy">Privacy Policy</a>. You can disable location access at any time
+          through your device settings, though this may limit the functionality of the Service.
+        </p>
+
+        <h2>8. Third-Party Services</h2>
+        <p>
+          The Service may contain links to or integrations with third-party services. We are not
+          responsible for the content, privacy practices, or terms of any third-party services.
+          Your use of third-party services is at your own risk.
+        </p>
+
+        <h2>9. Disclaimers</h2>
+        <p>
+          THE SERVICE IS PROVIDED &quot;AS IS&quot; AND &quot;AS AVAILABLE&quot; WITHOUT WARRANTIES
+          OF ANY KIND, WHETHER EXPRESS OR IMPLIED. WE DO NOT WARRANT THAT THE SERVICE WILL BE
+          UNINTERRUPTED, ERROR-FREE, OR SECURE. WE DO NOT GUARANTEE THE ACCURACY OF ANY CONTENT OR
+          RECOMMENDATIONS PROVIDED THROUGH THE SERVICE.
+        </p>
+
+        <h2>10. Limitation of Liability</h2>
+        <p>
+          TO THE MAXIMUM EXTENT PERMITTED BY LAW, MAPIER LABS INC. SHALL NOT BE LIABLE FOR ANY
+          INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, OR PUNITIVE DAMAGES ARISING FROM YOUR USE
+          OF THE SERVICE. OUR TOTAL LIABILITY SHALL NOT EXCEED THE AMOUNT YOU PAID TO US, IF ANY,
+          IN THE TWELVE MONTHS PRECEDING THE CLAIM.
+        </p>
+
+        <h2>11. Indemnification</h2>
+        <p>
+          You agree to indemnify and hold harmless Mapier Labs Inc., its officers, directors,
+          employees, and agents from any claims, damages, or expenses arising from your use of the
+          Service or violation of these Terms.
+        </p>
+
+        <h2>12. Termination</h2>
+        <p>
+          We may suspend or terminate your access to the Service at any time for any reason,
+          including violation of these Terms. You may delete your account at any time through the
+          app settings or by contacting <a href="mailto:support@mapier.ai">support@mapier.ai</a>.
+          Upon termination, your right to use the Service ceases immediately.
+        </p>
+
+        <h2>13. Changes to Terms</h2>
+        <p>
+          We may update these Terms from time to time. We will notify you of material changes by
+          posting the updated Terms on this page. Your continued use of the Service after changes
+          constitutes acceptance of the updated Terms.
+        </p>
+
+        <h2>14. Governing Law</h2>
+        <p>
+          These Terms are governed by the laws of the State of California, without regard to
+          conflict of law principles. Any disputes shall be resolved in the courts located in
+          San Francisco County, California.
+        </p>
+
+        <h2>15. Contact</h2>
+        <p>For questions about these Terms, please contact us:</p>
+        <ul>
+          <li>
+            Email: <a href="mailto:legal@mapier.ai">legal@mapier.ai</a>
+          </li>
+          <li>
+            Support: <a href="/support">mapier.ai/support</a>
+          </li>
+        </ul>
+        <p>Mapier Labs Inc.<br />San Francisco, CA</p>
+      </section>
+    </PageLayout>
+  );
+}

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next";
+import { TermsPage } from "./TermsPage";
+
+export const metadata: Metadata = {
+  title: "Terms of Service - Mapier",
+  description:
+    "Mapier's terms of service. Read the terms and conditions for using the Mapier app and website.",
+  alternates: { canonical: "/terms" },
+};
+
+export default function Terms() {
+  return <TermsPage />;
+}

--- a/components/PageLayout.tsx
+++ b/components/PageLayout.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useEffect } from "react";
+import Link from "next/link";
+
+interface PageLayoutProps {
+  children: React.ReactNode;
+}
+
+const NAV_LINKS = [
+  { href: "/support", label: "Support" },
+  { href: "/privacy", label: "Privacy" },
+  { href: "/terms", label: "Terms" },
+];
+
+export function PageLayout({ children }: PageLayoutProps) {
+  useEffect(() => {
+    document.documentElement.classList.add("page-scrollable");
+    return () => document.documentElement.classList.remove("page-scrollable");
+  }, []);
+
+  return (
+    <div className="page-layout">
+      <header className="page-header">
+        <Link href="/" className="page-header__logo">
+          Mapier
+        </Link>
+        <nav className="page-header__nav">
+          {NAV_LINKS.map((link) => (
+            <Link key={link.href} href={link.href} className="page-header__link">
+              {link.label}
+            </Link>
+          ))}
+        </nav>
+      </header>
+
+      <main className="page-main">{children}</main>
+
+      <footer className="page-footer">
+        <div className="page-footer__inner">
+          <div className="page-footer__brand">
+            <Link href="/" className="page-footer__logo">
+              Mapier
+            </Link>
+            <p className="page-footer__tagline">
+              The AI-personalized live map of social and local life.
+            </p>
+          </div>
+          <div className="page-footer__links">
+            <div className="page-footer__col">
+              <h4>Product</h4>
+              <Link href="/#waitlist">Join Waitlist</Link>
+              <a href="https://www.linkedin.com/company/mapier-labs/" target="_blank" rel="noopener noreferrer">
+                Careers
+              </a>
+            </div>
+            <div className="page-footer__col">
+              <h4>Legal</h4>
+              <Link href="/privacy">Privacy Policy</Link>
+              <Link href="/terms">Terms of Service</Link>
+            </div>
+            <div className="page-footer__col">
+              <h4>Support</h4>
+              <Link href="/support">Help Center</Link>
+              <a href="mailto:support@mapier.ai">support@mapier.ai</a>
+            </div>
+          </div>
+        </div>
+        <div className="page-footer__bottom">
+          <span>© {new Date().getFullYear()} Mapier Labs Inc. All rights reserved.</span>
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/components/PageLayout.tsx
+++ b/components/PageLayout.tsx
@@ -62,7 +62,7 @@ export function PageLayout({ children }: PageLayoutProps) {
             <div className="page-footer__col">
               <h4>Support</h4>
               <Link href="/support">Help Center</Link>
-              <a href="mailto:support@mapier.ai">support@mapier.ai</a>
+              <a href="mailto:hello@mapier.ai">hello@mapier.ai</a>
             </div>
           </div>
         </div>

--- a/components/landing/LandingExperience.tsx
+++ b/components/landing/LandingExperience.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback, type CSSProperties } from "react";
 import Image from "next/image";
+import Link from "next/link";
 import { useDraggableLanding } from "@/hooks/useDraggableLanding";
 import { Draggable } from "./Draggable";
 import { LandingHero } from "./LandingHero";
@@ -96,11 +97,12 @@ export function LandingExperience() {
       ))}
 
       <footer className="footer-bar">
-        <span>© {new Date().getFullYear()} Mapier Labs Inc.</span>
+        <span>© {new Date().getFullYear()} Mapier. All rights reserved.</span>
+        <span>Built by Mapier Labs with ❤️ in SF</span>
         <nav className="footer-bar__links">
-          <a href="/support">Support</a>
-          <a href="/privacy">Privacy</a>
-          <a href="/terms">Terms</a>
+          <Link href="/support">Support</Link>
+          <Link href="/privacy">Privacy</Link>
+          <Link href="/terms">Terms</Link>
         </nav>
       </footer>
 

--- a/components/landing/LandingExperience.tsx
+++ b/components/landing/LandingExperience.tsx
@@ -96,8 +96,12 @@ export function LandingExperience() {
       ))}
 
       <footer className="footer-bar">
-        <span>© {new Date().getFullYear()} Mapier. All rights reserved.</span>
-        <span>Built by Mapier Labs with ❤️ in SF</span>
+        <span>© {new Date().getFullYear()} Mapier Labs Inc.</span>
+        <nav className="footer-bar__links">
+          <a href="/support">Support</a>
+          <a href="/privacy">Privacy</a>
+          <a href="/terms">Terms</a>
+        </nav>
       </footer>
 
       <WaitlistModal open={waitlistOpen} onClose={closeWaitlist} />


### PR DESCRIPTION
## Summary

Apple Developer compliance pages + deep link sharing infrastructure:

- **Legal pages**: Added Support, Privacy Policy, and Terms of Service pages with shared PageLayout component
- **Deep link sharing**: Share routes for posts and profiles with OG meta tags and app redirect
- **App association**: Apple App Site Association and Android Asset Links for universal/deep links
- **Sitemap**: Auto-generated sitemap for SEO
- **Footer**: Restored original footer style (copyright + Built by Mapier Labs) with clickable Support/Privacy/Terms links
- **Support page cleanup**: Removed placeholder contact form and About section, keeping FAQ and Contact Us cards

## Test plan
- [x] Footer links (Support, Privacy, Terms) navigate correctly from landing page
- [x] Support page shows FAQ and Contact Us sections (no form or About section)
- [x] Privacy and Terms pages render with full content
- [x] Original footer text preserved ("Built by Mapier Labs with heart in SF")

🤖 Generated with [Claude Code](https://claude.com/claude-code)