### PR TITLE
feat: replace static map background with live geolocated map

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
 # Supabase (for waitlist)
 SUPABASE_URL=your-supabase-url
 SUPABASE_ANON_KEY=your-supabase-anon-key
+
+# Google Maps (for hero map background) — restrict by HTTP referrer in GCP Console
+NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=your-google-maps-browser-key

--- a/app/globals.css
+++ b/app/globals.css
@@ -62,8 +62,9 @@ body.is-dragging {
 .bg {
   position: fixed;
   inset: 0;
-  background: url("/landing/bg-map.png") center / cover no-repeat;
+  background: #e6e4df;
   z-index: 0;
+  pointer-events: none;
 }
 
 .reset-btn {

--- a/app/globals.css
+++ b/app/globals.css
@@ -65,6 +65,10 @@ body.is-dragging {
   background: #e6e4df;
   z-index: 0;
   pointer-events: none;
+  /* Scale up to crop Google Maps attribution at edges */
+  transform: scale(1.15);
+  transform-origin: center center;
+  overflow: hidden;
 }
 
 .reset-btn {
@@ -385,12 +389,6 @@ body.is-releasing {
     min-width: 200px;
     text-align: center;
     justify-content: center;
-  }
-
-  /* Background — zoom in slightly to crop attribution text */
-  .bg {
-    transform: scale(1.1);
-    transform-origin: center center;
   }
 
   /* Decorative stickers — scattered around periphery */

--- a/components/landing/LandingExperience.tsx
+++ b/components/landing/LandingExperience.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import { useDraggableLanding } from "@/hooks/useDraggableLanding";
 import { Draggable } from "./Draggable";
 import { LandingHero } from "./LandingHero";
+import { MapBackground } from "./MapBackground";
 import { WaitlistModal } from "./WaitlistModal";
 import { STICKERS } from "./landingConfig";
 
@@ -44,7 +45,7 @@ export function LandingExperience() {
 
   return (
     <>
-      <div className="bg" />
+      <MapBackground />
 
       <button className="reset-btn" type="button" title="Reset layout">
         <svg

--- a/components/landing/MapBackground.tsx
+++ b/components/landing/MapBackground.tsx
@@ -2,64 +2,79 @@
 
 import { useEffect, useRef } from "react";
 
-const CHICAGO: [number, number] = [41.8781, -87.6298];
+const CHICAGO = { lat: 41.8781, lng: -87.6298 };
 const DEFAULT_ZOOM = 13;
-const LEAFLET_VERSION = "1.9.4";
-const LEAFLET_CSS = `https://unpkg.com/leaflet@${LEAFLET_VERSION}/dist/leaflet.css`;
-const LEAFLET_JS = `https://unpkg.com/leaflet@${LEAFLET_VERSION}/dist/leaflet.js`;
+const GOOGLE_MAPS_API_KEY = process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY;
 
-type LeafletGlobal = {
-  map: (el: HTMLElement, opts: Record<string, unknown>) => LeafletMap;
-  tileLayer: (url: string, opts: Record<string, unknown>) => { addTo: (m: LeafletMap) => void };
-};
-
-type LeafletMap = {
-  setView: (center: [number, number], zoom: number, opts?: Record<string, unknown>) => void;
-  remove: () => void;
-};
+const MAP_STYLES: google.maps.MapTypeStyle[] = [
+  { featureType: "all", elementType: "labels.text.fill", stylers: [{ saturation: 36 }, { color: "#333333" }, { lightness: 40 }] },
+  { featureType: "all", elementType: "labels.text.stroke", stylers: [{ visibility: "on" }, { color: "#ffffff" }, { lightness: 16 }] },
+  { featureType: "all", elementType: "labels.icon", stylers: [{ visibility: "off" }] },
+  { featureType: "administrative", elementType: "geometry.fill", stylers: [{ color: "#fefefe" }, { lightness: 20 }] },
+  { featureType: "administrative", elementType: "geometry.stroke", stylers: [{ color: "#fefefe" }, { lightness: 17 }, { weight: 1.2 }] },
+  { featureType: "administrative", elementType: "labels.text", stylers: [{ visibility: "off" }] },
+  { featureType: "landscape", elementType: "geometry", stylers: [{ color: "#f5f5f5" }, { lightness: 20 }] },
+  { featureType: "landscape.natural", elementType: "labels", stylers: [{ visibility: "off" }] },
+  { featureType: "poi", elementType: "geometry", stylers: [{ color: "#f5f5f5" }, { lightness: 21 }] },
+  { featureType: "poi", elementType: "labels", stylers: [{ visibility: "off" }] },
+  { featureType: "poi.park", elementType: "geometry", stylers: [{ color: "#dedede" }, { lightness: 21 }] },
+  { featureType: "road", elementType: "labels.text", stylers: [{ visibility: "off" }] },
+  { featureType: "road.highway", elementType: "geometry.fill", stylers: [{ color: "#ffffff" }, { lightness: 17 }] },
+  { featureType: "road.highway", elementType: "geometry.stroke", stylers: [{ color: "#ffffff" }, { lightness: 29 }, { weight: 0.2 }] },
+  { featureType: "road.arterial", elementType: "geometry", stylers: [{ color: "#ffffff" }, { lightness: 18 }] },
+  { featureType: "road.local", elementType: "geometry", stylers: [{ color: "#ffffff" }, { lightness: 16 }] },
+  { featureType: "transit", elementType: "geometry", stylers: [{ color: "#f2f2f2" }, { lightness: 19 }] },
+  { featureType: "water", elementType: "geometry", stylers: [{ color: "#e9e9e9" }, { lightness: 17 }] },
+];
 
 declare global {
   interface Window {
-    L?: LeafletGlobal;
+    __initGoogleMaps?: () => void;
   }
 }
 
-function loadLeaflet(): Promise<LeafletGlobal> {
-  if (window.L) return Promise.resolve(window.L);
+let googleMapsPromise: Promise<typeof google> | null = null;
 
-  if (!document.querySelector(`link[data-leaflet="1"]`)) {
-    const link = document.createElement("link");
-    link.rel = "stylesheet";
-    link.href = LEAFLET_CSS;
-    link.dataset.leaflet = "1";
-    document.head.appendChild(link);
+function loadGoogleMaps(apiKey: string): Promise<typeof google> {
+  if (typeof window !== "undefined" && window.google?.maps?.Map) {
+    return Promise.resolve(window.google);
   }
+  if (googleMapsPromise) return googleMapsPromise;
 
-  return new Promise((resolve, reject) => {
-    const existing = document.querySelector<HTMLScriptElement>(`script[data-leaflet="1"]`);
-    if (existing) {
-      existing.addEventListener("load", () => resolve(window.L!));
-      existing.addEventListener("error", () => reject(new Error("leaflet load failed")));
+  googleMapsPromise = new Promise((resolve, reject) => {
+    if (document.querySelector(`script[data-gmaps="1"]`)) {
+      const poll = setInterval(() => {
+        if (window.google?.maps?.Map) {
+          clearInterval(poll);
+          resolve(window.google);
+        }
+      }, 50);
       return;
     }
+    window.__initGoogleMaps = () => {
+      delete window.__initGoogleMaps;
+      resolve(window.google);
+    };
     const script = document.createElement("script");
-    script.src = LEAFLET_JS;
+    script.src = `https://maps.googleapis.com/maps/api/js?key=${encodeURIComponent(apiKey)}&v=weekly&callback=__initGoogleMaps`;
     script.async = true;
-    script.dataset.leaflet = "1";
-    script.onload = () => resolve(window.L!);
-    script.onerror = () => reject(new Error("leaflet load failed"));
+    script.defer = true;
+    script.dataset.gmaps = "1";
+    script.onerror = () => reject(new Error("google maps load failed"));
     document.head.appendChild(script);
   });
+
+  return googleMapsPromise;
 }
 
-function getUserLocation(): Promise<[number, number]> {
+function getUserLocation(): Promise<google.maps.LatLngLiteral> {
   return new Promise((resolve, reject) => {
     if (!navigator.geolocation) {
       reject(new Error("geolocation unavailable"));
       return;
     }
     navigator.geolocation.getCurrentPosition(
-      (pos) => resolve([pos.coords.latitude, pos.coords.longitude]),
+      (pos) => resolve({ lat: pos.coords.latitude, lng: pos.coords.longitude }),
       reject,
       { timeout: 5000, maximumAge: 60 * 60 * 1000 }
     );
@@ -70,50 +85,50 @@ export function MapBackground() {
   const containerRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
+    if (!GOOGLE_MAPS_API_KEY) {
+      console.warn("[MapBackground] NEXT_PUBLIC_GOOGLE_MAPS_API_KEY not set");
+      return;
+    }
+
     let cancelled = false;
-    let map: LeafletMap | undefined;
+    let map: google.maps.Map | undefined;
 
     (async () => {
       try {
-        const L = await loadLeaflet();
+        const g = await loadGoogleMaps(GOOGLE_MAPS_API_KEY);
         if (cancelled || !containerRef.current) return;
 
-        map = L.map(containerRef.current, {
+        map = new g.maps.Map(containerRef.current, {
           center: CHICAGO,
           zoom: DEFAULT_ZOOM,
-          zoomControl: false,
-          attributionControl: false,
-          dragging: false,
-          scrollWheelZoom: false,
-          doubleClickZoom: false,
-          boxZoom: false,
-          keyboard: false,
-          touchZoom: false,
-          tap: false,
-          zoomSnap: 0.25,
+          disableDefaultUI: true,
+          gestureHandling: "none",
+          keyboardShortcuts: false,
+          clickableIcons: false,
+          backgroundColor: "#f5f5f5",
+          styles: MAP_STYLES,
         });
-
-        L.tileLayer("https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png", {
-          subdomains: "abcd",
-          maxZoom: 19,
-        }).addTo(map);
 
         try {
           const coords = await getUserLocation();
-          if (!cancelled && map) map.setView(coords, DEFAULT_ZOOM, { animate: true });
+          if (!cancelled && map) map.panTo(coords);
         } catch {
-          // geolocation denied / unavailable — Chicago default already set
+          // geolocation denied / unavailable — Chicago default
         }
       } catch {
-        // leaflet failed to load — leave background empty
+        // google maps failed to load — leave background empty
       }
     })();
 
     return () => {
       cancelled = true;
-      map?.remove();
+      map = undefined;
     };
   }, []);
 
-  return <div ref={containerRef} className="bg" aria-hidden />;
+  return (
+    <div className="bg" aria-hidden>
+      <div ref={containerRef} style={{ width: "100%", height: "100%" }} />
+    </div>
+  );
 }

--- a/components/landing/MapBackground.tsx
+++ b/components/landing/MapBackground.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+const CHICAGO: [number, number] = [41.8781, -87.6298];
+const DEFAULT_ZOOM = 13;
+const LEAFLET_VERSION = "1.9.4";
+const LEAFLET_CSS = `https://unpkg.com/leaflet@${LEAFLET_VERSION}/dist/leaflet.css`;
+const LEAFLET_JS = `https://unpkg.com/leaflet@${LEAFLET_VERSION}/dist/leaflet.js`;
+
+type LeafletGlobal = {
+  map: (el: HTMLElement, opts: Record<string, unknown>) => LeafletMap;
+  tileLayer: (url: string, opts: Record<string, unknown>) => { addTo: (m: LeafletMap) => void };
+};
+
+type LeafletMap = {
+  setView: (center: [number, number], zoom: number, opts?: Record<string, unknown>) => void;
+  remove: () => void;
+};
+
+declare global {
+  interface Window {
+    L?: LeafletGlobal;
+  }
+}
+
+function loadLeaflet(): Promise<LeafletGlobal> {
+  if (window.L) return Promise.resolve(window.L);
+
+  if (!document.querySelector(`link[data-leaflet="1"]`)) {
+    const link = document.createElement("link");
+    link.rel = "stylesheet";
+    link.href = LEAFLET_CSS;
+    link.dataset.leaflet = "1";
+    document.head.appendChild(link);
+  }
+
+  return new Promise((resolve, reject) => {
+    const existing = document.querySelector<HTMLScriptElement>(`script[data-leaflet="1"]`);
+    if (existing) {
+      existing.addEventListener("load", () => resolve(window.L!));
+      existing.addEventListener("error", () => reject(new Error("leaflet load failed")));
+      return;
+    }
+    const script = document.createElement("script");
+    script.src = LEAFLET_JS;
+    script.async = true;
+    script.dataset.leaflet = "1";
+    script.onload = () => resolve(window.L!);
+    script.onerror = () => reject(new Error("leaflet load failed"));
+    document.head.appendChild(script);
+  });
+}
+
+function getUserLocation(): Promise<[number, number]> {
+  return new Promise((resolve, reject) => {
+    if (!navigator.geolocation) {
+      reject(new Error("geolocation unavailable"));
+      return;
+    }
+    navigator.geolocation.getCurrentPosition(
+      (pos) => resolve([pos.coords.latitude, pos.coords.longitude]),
+      reject,
+      { timeout: 5000, maximumAge: 60 * 60 * 1000 }
+    );
+  });
+}
+
+export function MapBackground() {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    let map: LeafletMap | undefined;
+
+    (async () => {
+      try {
+        const L = await loadLeaflet();
+        if (cancelled || !containerRef.current) return;
+
+        map = L.map(containerRef.current, {
+          center: CHICAGO,
+          zoom: DEFAULT_ZOOM,
+          zoomControl: false,
+          attributionControl: false,
+          dragging: false,
+          scrollWheelZoom: false,
+          doubleClickZoom: false,
+          boxZoom: false,
+          keyboard: false,
+          touchZoom: false,
+          tap: false,
+          zoomSnap: 0.25,
+        });
+
+        L.tileLayer("https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png", {
+          subdomains: "abcd",
+          maxZoom: 19,
+        }).addTo(map);
+
+        try {
+          const coords = await getUserLocation();
+          if (!cancelled && map) map.setView(coords, DEFAULT_ZOOM, { animate: true });
+        } catch {
+          // geolocation denied / unavailable — Chicago default already set
+        }
+      } catch {
+        // leaflet failed to load — leave background empty
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      map?.remove();
+    };
+  }, []);
+
+  return <div ref={containerRef} className="bg" aria-hidden />;
+}

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
+    "@types/google.maps": "^3.64.0",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1096,6 +1096,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/google.maps@npm:^3.64.0":
+  version: 3.64.0
+  resolution: "@types/google.maps@npm:3.64.0"
+  checksum: 10c0/59895cade8d70d9d0b2a40b0edeea683555d117cfb4467079357eb8cc81a5e29358a6b22d4c1e3ce2618e3125ecf8853b9a108ada11a33c47f01b8db51a65d5f
+  languageName: node
+  linkType: hard
+
 "@types/json-schema@npm:^7.0.15":
   version: 7.0.15
   resolution: "@types/json-schema@npm:7.0.15"
@@ -3513,6 +3520,7 @@ __metadata:
   dependencies:
     "@supabase/supabase-js": "npm:^2.97.0"
     "@tailwindcss/postcss": "npm:^4"
+    "@types/google.maps": "npm:^3.64.0"
     "@types/node": "npm:^20"
     "@types/react": "npm:^19"
     "@types/react-dom": "npm:^19"


### PR DESCRIPTION
## Summary

- Swaps the static `bg-map.png` hero background for an interactive Leaflet map rendered with CartoDB Voyager tiles.
- Centers on the visitor's geolocation; falls back to **Chicago** (41.8781, -87.6298) when permission is denied, the request times out, or geolocation is unavailable.
- Map is fully non-interactive (`dragging`, scroll/touch/box/key zoom all off, `pointer-events: none` on the container) so the existing draggable stickers continue to receive all input unchanged.

## Implementation notes

- Leaflet is loaded from a CDN at runtime (`unpkg`) instead of being added as an npm dep — this avoids any package.json/yarn.lock churn and keeps the bundle small.
- Tile attribution control is hidden (`attributionControl: false`) for a cleaner background. If we want to be strict about CartoDB/OSM ToS we can re-enable it or switch to Mapbox/MapLibre with a paid token later.
- `bg-map.png` is left in the repo since `app/not-found.tsx` still references it.

## Test plan

- [ ] `yarn install && yarn dev`, open `http://localhost:3000`
- [ ] Allow geolocation → map recenters to your current city
- [ ] Deny geolocation (or test in a private window with location off) → map stays on Chicago
- [ ] Verify draggable phone + stickers still drag normally over the map
- [ ] Resize to mobile (≤768px) → background still covers viewport (the existing `transform: scale(1.1)` mobile rule still applies)
- [ ] `yarn build` succeeds
